### PR TITLE
Fully qualify pdf::Result in macro expansion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ fn impl_object_for_enum(ast: &DeriveInput, variants: &Vec<Variant>) -> quote::To
                     }
                 )
             }
-            fn from_primitive(p: Primitive, _resolve: &Resolve) -> Result<Self> {
+            fn from_primitive(p: Primitive, _resolve: &Resolve) -> ::pdf::Result<Self> {
                 #from_primitive_code
             }
         }


### PR DESCRIPTION
If pdf_derive is used from a scope where `pdf::Result` has not been imported, the generated `from_primitive` function will have a return type of `Result<Self>`, and `Result` will be resolved to `std::Result`. This results in an error about the number of type arguments. The proposed change will emit `::pdf::Result<Self>` as the return type, so it won't matter what has been imported in the context where the macro is used.